### PR TITLE
Remove style on .framerLayer

### DIFF
--- a/gotcha.coffee
+++ b/gotcha.coffee
@@ -238,10 +238,6 @@ Utils.insertCSS """
 		right: 36px;
 	}
 
-	.framerLayer { 
-		pointer-events: all !important; 
-		} 
-	
 	.IgnorePointerEvents {
 		pointer-events: none !important; 
 	}


### PR DESCRIPTION
In general it is a bad idea to add styling on .framerLayer (because the Framer Library adds custom styling to it), but having an `!important` flag here breaks [`layer.ignoreEvents`](https://github.com/koenbok/Framer/blob/master/framer/Layer.coffee#L258). This is used a for invisible layers and layers without events. Try adding `gotcha` to the Welcome Window Tutorial in Framer to see it break basic interactions.

I'm not sure what this style is supposed to do, and have been able to track it down to [the initial commit](https://github.com/steveruizok/gotcha/blob/97dffd58c35bef0ab8d4e534c1601746df29fd11/gotcha.coffee#L1012) but assume it is a counter to `.IgnorePointerEvents`. However, adding and removing that style should be enough, and even better would be to use the ignoreEvents property of a Framer Layer to get this behaviour.